### PR TITLE
dub package info added.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+	"description": "Glamour is an OpenGL wrapper for the D programming language.",
+	"targetName": "glamour",
+	"authors": [
+		"David Herberth"
+	],
+	"version": "~master",
+	"homepage": "https://github.com/Dav1dde/glamour",
+	"name": "glamour",
+	"copyright": "Copyright © 2011-2013, David Herberth",
+	"targetType": "staticLibrary",
+	"sourcePaths": [
+		"glamour"
+	],
+	"configurations": [
+		{
+			"name": "Derelict3-gl3n-SDLImage",
+			"versions": [
+				"Derelict3",
+				"gl3n",
+				"SDLImage"
+			],
+			"dependencies": {
+				"gl3n": "~master",
+				"derelict": "~master"
+			},
+		},
+		{
+			"name": "Derelict3-SDLImage",
+			"versions": [
+				"Derelict3",
+				"SDLImage"
+			],
+			"dependencies": {
+				"derelict": "~master"
+			},
+		}
+	]
+}


### PR DESCRIPTION
simple dub package.json added. It provides only two configurations:
1. "Derelict3-gl3n-SDLImage": Derelict3, gl3n and SDLImage
2. "Derelict3-SDLImage": Derelict3 and SDLImage
Other configurations can be added easily, but I didn't to avoid probable garbage because I'm not sure it is the best way to enumerate all possible combinations.
