### PR TITLE
compatibility with recent dub versions

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -12,6 +12,9 @@
 	"sourcePaths": [
 		"glamour"
 	],
+	"importPaths": [
+		"."
+	],
 	"configurations": [
 		{
 			"name": "Derelict3-gl3n-SDLImage2",
@@ -22,8 +25,8 @@
 			],
 			"dependencies": {
 				"gl3n": "~master",
-				"derelict-gl3": "~master",
-				"derelict-sdl2": "~master"
+				"derelict-gl3": ">=1.0.6",
+				"derelict-sdl2": ">=1.2.6"
 			},
 		},
 		{
@@ -33,8 +36,8 @@
 				"SDLImage2"
 			],
 			"dependencies": {
-				"derelict-gl3": "~master",
-				"derelict-sdl2": "~master"
+				"derelict-gl3": ">=1.0.6",
+				"derelict-sdl2": ">=1.2.6"
 			},
 		},
 		{
@@ -52,8 +55,8 @@
 				"SDLImage2"
 			],
 			"dependencies": {
-				"derelict-gl3": "~master",
-				"derelict-sdl2": "~master"
+				"derelict-gl3": ">=1.0.6",
+				"derelict-sdl2": ">=1.2.6"
 			}
 		},
 		{
@@ -71,8 +74,8 @@
 				"SDLImage2"
 			],
 			"dependencies": {
-				"derelict-gl3": "~master",
-				"derelict-sdl2": "~master"
+				"derelict-gl3": ">=1.0.6",
+				"derelict-sdl2": ">=1.2.6"
 			}
 		}
 	]


### PR DESCRIPTION
It now refers to specific versions for dub. Also I added an explicit importPath to make it clear where the import tree starts.

The gl3n dependency will need tagging with an explicit release too, but that would require action on https://github.com/Dav1dde/gl3n/issues/42
