### PR TITLE
No more GL_TEXTURE_PROXY_2D_ARRAY for Texture2DArray

### DIFF
--- a/glamour/texture.d
+++ b/glamour/texture.d
@@ -413,4 +413,4 @@ class Texture3DBase(GLenum target_) : ITexture {
 }
 
 alias Texture3DBase!(GL_TEXTURE_3D) Texture3D;
-alias Texture3DBase!(GL_PROXY_TEXTURE_2D_ARRAY) Texture2DArray;
+alias Texture3DBase!(GL_TEXTURE_2D_ARRAY) Texture2DArray;


### PR DESCRIPTION
Perhaps I'm misunderstanding your intent, but GL_PROXY_TEXTUREs are for querying whether particular texture configurations are supported, not for general use as textures.